### PR TITLE
Do not break contact sync if there's no delivery address for an order

### DIFF
--- a/htdocs/ecommerceng/class/business/eCommerceSynchro.class.php
+++ b/htdocs/ecommerceng/class/business/eCommerceSynchro.class.php
@@ -1287,6 +1287,12 @@ class eCommerceSynchro
     {
         global $conf;
 
+	//If there's no remote_id. For example an order without delivery address
+	if (!$socpeopleArray['remote_id'] || $socpeopleArray['remote_id'] == '') {
+            dol_syslog("***** eCommerceSynchro synchSocPeople remote_id is empty !");
+	    return false;
+	}
+
         $error=0;
 
         try {

--- a/htdocs/ecommerceng/class/business/eCommerceSynchro.class.php
+++ b/htdocs/ecommerceng/class/business/eCommerceSynchro.class.php
@@ -1281,7 +1281,7 @@ class eCommerceSynchro
      * Synchronize socpeople to update for a society: Create or update it into dolibarr, then update the ecommerce_socpeople table.
      *
      * @param   array   $socpeopleArray     Array with all params to synchronize
-     * @return  int                         Id of socpeople into Dolibarr if OK and false if KO
+     * @return  int                         Id of socpeople into Dolibarr if OK, 0 if no sync to do and false if KO
      */
     public function synchSocpeople($socpeopleArray)
     {
@@ -1289,8 +1289,8 @@ class eCommerceSynchro
 
 	//If there's no remote_id. For example an order without delivery address
 	if (!$socpeopleArray['remote_id'] || $socpeopleArray['remote_id'] == '') {
-            dol_syslog("***** eCommerceSynchro synchSocPeople remote_id is empty !");
-	    return false;
+            dol_syslog("***** eCommerceSynchro synchSocPeople remote_id is empty, sync is ignored !");
+	    return 0;
 	}
 
         $error=0;


### PR DESCRIPTION
Do not break synchro if there's no customer delivery address on an order by skipping the contact creation if remote_id is empty